### PR TITLE
UrlAlias stringlength 64 --> 512

### DIFF
--- a/CphCloud.Packages.UrlAlias/Data/IUrlAlias.cs
+++ b/CphCloud.Packages.UrlAlias/Data/IUrlAlias.cs
@@ -22,9 +22,9 @@ namespace CphCloud.Packages.UrlAlias.Data
         [ImmutableFieldId("{942BDDA5-A5EF-4E31-A5FF-85FBED905F12}")]
         Guid Id { get; set; }
 
-        [StoreFieldType(PhysicalStoreFieldType.String, 64)]
+        [StoreFieldType(PhysicalStoreFieldType.String, 512)]
         [ImmutableFieldId("{C7DEDEAA-686F-42BB-A546-AE8334EB2357}")]
-        [StringSizeValidator(1, 64)]
+        [StringSizeValidator(1, 512)]
         string UrlAlias { get; set; }
 
         [StoreFieldType(PhysicalStoreFieldType.String, 512)]


### PR DESCRIPTION
After discussing with Magnus, I increased the maximum string length of the UrlAlias field to 512 characters, to allow for longer source URLs. I was able to get this working without a reinstall, just replacing the assembly in /bin. 

This change possibly takes the project out of its original intent a little bit, but short source URLs are obviously still possible.
