### PR TITLE
Fixed issue for 2 or more localized domains using the same path

### DIFF
--- a/CphCloud.Packages.UrlAlias/UrlAliasHttpModule.cs
+++ b/CphCloud.Packages.UrlAlias/UrlAliasHttpModule.cs
@@ -38,14 +38,13 @@ namespace CphCloud.Packages.UrlAlias
                 {
                     using (var conn = new DataConnection())
                     {
+                        var hostnameId = conn.Get<IHostnameBinding>().Single(x => x.Hostname == httpApplication.Request.Url.Host).Id;
                         var matchingUrlAlias =
                             conn.Get<IUrlAlias>()
-                                .SingleOrDefault(x => x.UrlAlias.ToLower() == incomingUrlPath.ToLower());
+                                .SingleOrDefault(x => x.UrlAlias.ToLower() == incomingUrlPath.ToLower() && (x.Hostname == hostnameId || x.Hostname == Guid.Empty));
 
                         if (matchingUrlAlias != null
-                            && matchingUrlAlias.Enabled
-                            && (matchingUrlAlias.Hostname == Guid.Empty || conn.Get<IHostnameBinding>()
-                                .Single(x => x.Id == matchingUrlAlias.Hostname).Hostname == httpApplication.Request.Url.Host))
+                            && matchingUrlAlias.Enabled)
                         {
                             matchingUrlAlias.LastUse = DateTime.Now;
                             matchingUrlAlias.UseCount++;


### PR DESCRIPTION
If you have two or more localizations, say a US site and a European site with
the same path that needs to be redirected say (/About-Us-> /AboutUs), it
would fail because the query was keying off the URL path only and would return 2 results in this example, one from each hostname.  With this change the match query keys on the URL path and
the hostname ensuring 1 result.

I've also modified the following if condition since we no longer have to
test if the hostname matches the inbound hostname since we did that in
the match query.