### PR TITLE
Feature; ability to turn off data collection. Minor fix for missing URL Configuration

### DIFF
--- a/CphCloud.Packages.UrlAlias/UrlAliasHttpModule.cs
+++ b/CphCloud.Packages.UrlAlias/UrlAliasHttpModule.cs
@@ -6,6 +6,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Web;
+using System.Web.Configuration;
 
 namespace CphCloud.Packages.UrlAlias
 {
@@ -46,9 +47,14 @@ namespace CphCloud.Packages.UrlAlias
                         if (matchingUrlAlias != null
                             && matchingUrlAlias.Enabled)
                         {
-                            matchingUrlAlias.LastUse = DateTime.Now;
-                            matchingUrlAlias.UseCount++;
-                            conn.Update(matchingUrlAlias);
+                            bool useCountEnabled = (WebConfigurationManager.AppSettings["UrlAlias::UseCountEnabled"] ?? "true").ToLower() != "false";
+
+                            if (useCountEnabled)
+                            {
+                                matchingUrlAlias.LastUse = DateTime.Now;
+                                matchingUrlAlias.UseCount++;
+                                conn.Update(matchingUrlAlias);
+                            }
 
                             httpApplication.Response.Clear();
                             httpApplication.Response.StatusCode = matchingUrlAlias.HttpStatusCode;

--- a/CphCloud.Packages.UrlAlias/UrlAliasHttpModule.cs
+++ b/CphCloud.Packages.UrlAlias/UrlAliasHttpModule.cs
@@ -38,7 +38,7 @@ namespace CphCloud.Packages.UrlAlias
                 {
                     using (var conn = new DataConnection())
                     {
-                        var hostnameId = conn.Get<IHostnameBinding>().Single(x => x.Hostname == httpApplication.Request.Url.Host).Id;
+                        var hostnameId = conn.Get<IHostnameBinding>().Where(x => x.Hostname == httpApplication.Request.Url.Host).Select(x => x.Id).FirstOrDefault();
                         var matchingUrlAlias =
                             conn.Get<IUrlAlias>()
                                 .SingleOrDefault(x => x.UrlAlias.ToLower() == incomingUrlPath.ToLower() && (x.Hostname == hostnameId || x.Hostname == Guid.Empty));

--- a/CphCloud.Packages.UrlAlias/_Package/Web.config/Install.xsl
+++ b/CphCloud.Packages.UrlAlias/_Package/Web.config/Install.xsl
@@ -13,4 +13,12 @@
 			</xsl:if>
 		</xsl:copy>
 	</xsl:template>
+	<xsl:template match="/configuration/appSettings">
+		<xsl:copy>
+			<xsl:apply-templates select="@* | node()" />
+			<xsl:if test="count(add[@name='UrlAlias::UseCountEnabled'])=0">
+				<add key="UrlAlias::UseCountEnabled" value="true" />
+			</xsl:if>
+		</xsl:copy>
+	</xsl:template>
 </xsl:stylesheet>

--- a/CphCloud.Packages.UrlAlias/_Package/Web.config/Uninstall.xsl
+++ b/CphCloud.Packages.UrlAlias/_Package/Web.config/Uninstall.xsl
@@ -6,4 +6,5 @@
 		</xsl:copy>
 	</xsl:template>
 	<xsl:template match="/configuration/system.webServer/modules/add[@name='UrlAlias']" />
+	<xsl:template match="/configuration/appSettings/add[@key='UrlAlias::UseCountEnabled']" />
 </xsl:stylesheet>


### PR DESCRIPTION
 **Feature added, turning on/off data (Use Count) collection via app settings in web.config**

You can now turn off "Use Count" by having this setting in web.config app settings:

`<add key="UrlAlias::UseCountEnabled" value="false" />`

Any other value than false, or if the element is missing, will keep the data collection running as usual.

For scaled out deployments sharing a common disk (like Azure Web Apps) , while running on the C1 XML data store, multi node updates to the same physical file can create problems under heavy load. Being able to turn off data collection can eliminate this issue.

**Fix: Package now also works without any existing "URL Configuration" in C1**

Would fail if no host name match was found in IHostnameBinding (C1's URL Configuration settings)